### PR TITLE
chore: simplify, modernize (Go 1.26), update deps

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -48,7 +48,9 @@ go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhO
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
 go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA6tzHBPODAiquo=
 go.opentelemetry.io/otel/sdk v1.44.0 h1:nHYwb9lK+fJPU/dnT6s7W7Z8itMWyqrnVfbheVYrZ58=
+go.opentelemetry.io/otel/sdk v1.44.0/go.mod h1:Osuydd3Se74nqjAKxid74N5eC+jfEqfTegHRnq58oK0=
 go.opentelemetry.io/otel/sdk/metric v1.44.0 h1:3LlKgI+VjbVsjNRFZJZAJ30WjXC5VkNRks6si09iEfI=
+go.opentelemetry.io/otel/sdk/metric v1.44.0/go.mod h1:5B5pMARnXxKhltooO4xUuCBorl65a4EpnTalObqOigA=
 go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/6gtIk=
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=

--- a/rpc.go
+++ b/rpc.go
@@ -2,8 +2,10 @@ package informer
 
 import (
 	"context"
-	stderr "errors"
+	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"time"
 
 	"connectrpc.com/connect"
@@ -15,8 +17,8 @@ import (
 const jobsTimeout = time.Minute
 
 var (
-	errNoSuchPlugin       = stderr.New("no such plugin")
-	errNoWorkerManagement = stderr.New("plugin does not support workers management")
+	errNoSuchPlugin       = errors.New("no such plugin")
+	errNoWorkerManagement = errors.New("plugin does not support workers management")
 )
 
 type rpc struct {
@@ -24,18 +26,22 @@ type rpc struct {
 }
 
 func (r *rpc) ListPlugins(_ context.Context, _ *connect.Request[informerV1.ListPluginsRequest]) (*connect.Response[informerV1.PluginsList], error) {
-	plugins := make([]string, 0, len(r.plugin.withWorkers))
-	for name := range r.plugin.withWorkers {
-		plugins = append(plugins, name)
-	}
-	return connect.NewResponse(&informerV1.PluginsList{Plugins: plugins}), nil
+	return connect.NewResponse(&informerV1.PluginsList{Plugins: slices.Collect(maps.Keys(r.plugin.withWorkers))}), nil
+}
+
+func noSuchPlugin(name string) error {
+	return fmt.Errorf("%w: %s", errNoSuchPlugin, name)
+}
+
+func noWorkerManagement(name string) error {
+	return fmt.Errorf("%w: %s", errNoWorkerManagement, name)
 }
 
 func (r *rpc) GetWorkers(_ context.Context, req *connect.Request[informerV1.GetWorkersRequest]) (*connect.Response[informerV1.WorkersList], error) {
 	name := req.Msg.GetPlugin()
 	svc, ok := r.plugin.withWorkers[name]
 	if !ok {
-		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("%w: %s", errNoSuchPlugin, name))
+		return nil, connect.NewError(connect.CodeNotFound, noSuchPlugin(name))
 	}
 
 	states := svc.Workers()
@@ -59,19 +65,19 @@ func (r *rpc) GetJobs(ctx context.Context, req *connect.Request[informerV1.GetJo
 	name := req.Msg.GetPlugin()
 	svc, ok := r.plugin.withJobs[name]
 	if !ok {
-		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("%w: %s", errNoSuchPlugin, name))
+		return nil, connect.NewError(connect.CodeNotFound, noSuchPlugin(name))
 	}
 
-	jobsCtx, cancel := context.WithTimeoutCause(ctx, jobsTimeout, stderr.New("JOBS operation canceled, timeout reached (1m)"))
+	jobsCtx, cancel := context.WithTimeoutCause(ctx, jobsTimeout, fmt.Errorf("JOBS operation canceled, timeout reached (%s)", jobsTimeout))
 	defer cancel()
 
 	states, err := svc.JobsState(jobsCtx)
 	if err != nil {
 		code := connect.CodeInternal
 		switch {
-		case stderr.Is(err, context.Canceled):
+		case errors.Is(err, context.Canceled):
 			code = connect.CodeCanceled
-		case stderr.Is(err, context.DeadlineExceeded):
+		case errors.Is(err, context.DeadlineExceeded):
 			code = connect.CodeDeadlineExceeded
 		}
 		return nil, connect.NewError(code, err)
@@ -98,7 +104,7 @@ func (r *rpc) AddWorker(_ context.Context, req *connect.Request[informerV1.AddWo
 	name := req.Msg.GetPlugin()
 	mgr, ok := r.plugin.workersManager[name]
 	if !ok {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("%w: %s", errNoWorkerManagement, name))
+		return nil, connect.NewError(connect.CodeFailedPrecondition, noWorkerManagement(name))
 	}
 	if err := mgr.AddWorker(); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
@@ -110,7 +116,7 @@ func (r *rpc) RemoveWorker(ctx context.Context, req *connect.Request[informerV1.
 	name := req.Msg.GetPlugin()
 	mgr, ok := r.plugin.workersManager[name]
 	if !ok {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, fmt.Errorf("%w: %s", errNoWorkerManagement, name))
+		return nil, connect.NewError(connect.CodeFailedPrecondition, noWorkerManagement(name))
 	}
 	if err := mgr.RemoveWorker(ctx); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -155,7 +155,9 @@ go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhO
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
 go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA6tzHBPODAiquo=
 go.opentelemetry.io/otel/sdk v1.44.0 h1:nHYwb9lK+fJPU/dnT6s7W7Z8itMWyqrnVfbheVYrZ58=
+go.opentelemetry.io/otel/sdk v1.44.0/go.mod h1:Osuydd3Se74nqjAKxid74N5eC+jfEqfTegHRnq58oK0=
 go.opentelemetry.io/otel/sdk/metric v1.44.0 h1:3LlKgI+VjbVsjNRFZJZAJ30WjXC5VkNRks6si09iEfI=
+go.opentelemetry.io/otel/sdk/metric v1.44.0/go.mod h1:5B5pMARnXxKhltooO4xUuCBorl65a4EpnTalObqOigA=
 go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/6gtIk=
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=


### PR DESCRIPTION
## Applied fixes (rpc.go)

**S — Simplify (4 findings):**
- Dropped misleading `stderr "errors"` import alias — renamed to stdlib `errors` directly
- Extracted `noSuchPlugin(name)` helper — deduplicates `fmt.Errorf("%w: %s", errNoSuchPlugin, name)` at two call sites (GetWorkers, GetJobs)
- Extracted `noWorkerManagement(name)` helper — same dedup for AddWorker/RemoveWorker
- Fixed stale hardcoded `"1m"` string in `WithTimeoutCause` message — now derived from the `jobsTimeout` constant via `fmt.Errorf("... (%s)", jobsTimeout)` so it stays in sync if the constant ever changes

**M — Modern Go (1 finding):**
- `ListPlugins`: replaced manual `make+for range` key-collect loop with `slices.Collect(maps.Keys(r.plugin.withWorkers))` (Go 1.23+, available under Go 1.26 toolchain)

## Deps

`go get -u all && go mod tidy` in root and `tests/`; `go work sync` at workspace root.

